### PR TITLE
change /api/v3 as /api/v4

### DIFF
--- a/public/services/gitlab.js
+++ b/public/services/gitlab.js
@@ -12,7 +12,7 @@ app
 
     gitlab.prototype.callapi = function(method, path) {
         var deferred = $q.defer();
-        var url = Config.gitlabUrl.replace(/\/*$/, "") + '/api/v3' + path;
+        var url = Config.gitlabUrl.replace(/\/*$/, "") + '/api/v4' + path;
 
         $http({
             url: url,


### PR DESCRIPTION
API requests are done through /api/v3 endpoint. But new versions of Gitlab does not accept it at throws below exception. 

{"error":"API V3 is no longer supported. Use API V4 instead."}

Same request with /api/v4 is ok.